### PR TITLE
Add missing parameters in cluster.ini

### DIFF
--- a/DSTClusterConfig/cluster.ini
+++ b/DSTClusterConfig/cluster.ini
@@ -18,6 +18,9 @@ max_players = 16
 pvp = false
 ;; true|false
 pause_when_empty = true
+;; Set to true to enable voting features.
+;; true|false
+vote_enabled = true
 
 [NETWORK]
 ;; cooperative|competitive|social|madness
@@ -32,6 +35,10 @@ cluster_password = YouShallNotPass!!!
 autosaver_enabled = true
 ;; true|false
 enable_vote_kick = false
+;; This is the number of times per-second that the server sends updates to clients. Increasing
+;; this may improve precision, but will result in more network traffic. It is recommended to
+;; leave this at the default value of 15. If you do change this option, do so only for LAN games,
+;; and use a number evenly divisible into 60 (15, 20, 30).
 ;; 10|15|30|60
 tick_rate = 15
 ;; milliseconds before unresponsive clients gets kicked out
@@ -44,6 +51,9 @@ connection_timeout = 8000
 ; offline_server = true
 
 [MISC]
+;; Maximum number of snapshots to retain. These snapshots are created every time a save occurs,
+;; and are available in the “Rollback” tab on the “Host Game” screen.
+max_snapshots = 6
 ;; true|false
 console_enabled = true
 
@@ -65,6 +75,10 @@ console_enabled = true
 ;; disabling `cluster_password` above if enabling this feature.
 ;; true|false
 ; steam_group_only = false
+
+;; When this is set to true, admins of the steam group specified in steam_group_id will also have admin
+;; status on the server.
+; steam_group_admins = false
 
 [SHARD]
 ;;; [CHANGE THIS]

--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # Don't Starve Together - Dedicated Server
 
+[![Automated Docker Builds](https://img.shields.io/docker/automated/mathielo/dst-dedicated-server.svg)](https://cloud.docker.com/repository/docker/mathielo/dst-dedicated-server)
+[![Docker Build State](https://img.shields.io/docker/build/mathielo/dst-dedicated-server.svg)](https://cloud.docker.com/repository/docker/mathielo/dst-dedicated-server)
+[![Docker Image Pulls](https://img.shields.io/docker/pulls/mathielo/dst-dedicated-server.svg)](https://cloud.docker.com/repository/docker/mathielo/dst-dedicated-server)
+[![License: MIT]( https://img.shields.io/github/license/mathielo/dst-dedicated-server.svg)](https://github.com/mathielo/dst-dedicated-server/blob/master/LICENSE.md)
+[![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-round)](http://makeapullrequest.com)
+
 DST Dedicated Server Guide for all platforms (Linux, Mac, Windows) with Docker.
 
 The purpose of this project is to have DST servers up and running with the **bare minimum** necessary setup.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 services:
   dst_caves:
     container_name: dst_caves
-    image: mathielo/dst-dedicated-server:0.3.0
+    image: mathielo/dst-dedicated-server:0.3.1
     ports:
       - 10998:10998/udp
     networks:
@@ -17,7 +17,7 @@ services:
 
   dst_master:
     container_name: dst_master
-    image: mathielo/dst-dedicated-server:0.3.0
+    image: mathielo/dst-dedicated-server:0.3.1
     networks:
       - dst_cluster
     ports:

--- a/docs/ClusterToken.md
+++ b/docs/ClusterToken.md
@@ -12,7 +12,9 @@ For this project, the `cluster_token.txt` file is located in `DSTClusterConfig/c
 
 Enter the game and press "Play". After you're logged in, bring up the console (by pressing `~`) and type the following command:
 
+```
 TheNet:GenerateClusterToken()
+```
 
 Press enter. The console will go away, and a `cluster_token.txt` was generated in:
  - Unix: `~/.klei/DoNotStarveTogether`


### PR DESCRIPTION
Adds some missing parameters as noted in #14. Also generated a fresher image since the last release was quite outdated.